### PR TITLE
bump rymndhng/release-on-push-action from v0.16.0 -> v0.28.0

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - id: release
-        uses: rymndhng/release-on-push-action@v0.16.0
+        uses: rymndhng/release-on-push-action@v0.28.0
         with:
           # If the PR has the label release:major, release:minor, or release:patch, this will override bump_version_scheme
           bump_version_scheme: patch


### PR DESCRIPTION
the v0.16.0 version of that resource is no longer listed on the market place, this bumps us up to the latest version