### PR TITLE
Feature/relative path fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func main() {
 
 	switch command {
 	case merge.FullCommand():
-		pipeline, err := ioutil.ReadFile((*pipelineFile).Name())
+		pipeline, err := os.ReadFile((*pipelineFile).Name())
 		if err != nil {
 			log.Fatalf("Error reading pipeline file: %v", err)
 		}
@@ -54,7 +53,7 @@ func main() {
 		if *outputFile == "-" || *outputFile == "" {
 			_, err = os.Stdout.WriteString(output)
 		} else {
-			err = ioutil.WriteFile(*outputFile, []byte(output), 0644)
+			err = os.WriteFile(*outputFile, []byte(output), 0644)
 		}
 
 		if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -164,7 +163,7 @@ func writeIncorrectOutputFile(output string, test *testCase) {
 		}
 	}
 
-	err = ioutil.WriteFile("incorrect_output"+string(os.PathSeparator)+"pipeline.yml", []byte(output), 0644)
+	err = os.WriteFile("incorrect_output"+string(os.PathSeparator)+"pipeline.yml", []byte(output), 0644)
 	if err != nil {
 		log.Printf("Unable to create incorrect_output file for %v: %v", test, err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -100,6 +100,29 @@ func TestPerformMerge(t *testing.T) {
 	}
 }
 
+// TestMergeBasenameFallback exercises the `-d`-relative fallback in
+// getYamlMap. uav is run from testdata/ (not chdir-ed into nested_dir/), so
+// the pipeline's `- template: jobs/test.yml` and the nested
+// `- template: jobs/resources/repo.yml` cannot resolve from disk — both must
+// come from the template index built out of `-d nested_dir/jobs`, keyed by
+// basename.
+func TestMergeBasenameFallback(t *testing.T) {
+	if _, err := os.Stat("testdata"); err == nil {
+		if err := os.Chdir("testdata"); err != nil {
+			t.Fatalf("Unable to chdir to testdata: %v", err)
+		}
+	}
+
+	output, err := performMerge(input, nil, []string{"nested_dir/jobs"})
+	if err != nil {
+		t.Fatalf("performMerge error: %v", err)
+	}
+
+	if output != expectedOutput {
+		t.Errorf("Incorrect output:\n%s", output)
+	}
+}
+
 func doTest(t *testing.T, test *testCase) {
 	err := os.Chdir(test.workingDir)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -107,7 +107,7 @@ func TestPerformMerge(t *testing.T) {
 // come from the template index built out of `-d nested_dir/jobs`, keyed by
 // basename.
 func TestMergeBasenameFallback(t *testing.T) {
-	if _, err := os.Stat("testdata"); err == nil {
+	if _, err := os.Stat("nested_dir/jobs"); err != nil {
 		if err := os.Chdir("testdata"); err != nil {
 			t.Fatalf("Unable to chdir to testdata: %v", err)
 		}

--- a/pkg/pipeline/merge.go
+++ b/pkg/pipeline/merge.go
@@ -15,7 +15,10 @@ func merge(p1 Pipeline, p2 Pipeline) (Pipeline, error) {
 	out.Merge = appendArrayInterfaceNoCheck(p1.Merge, p2.Merge)
 	out.ResourceTypes, resourceTypesOK = mergeArrayInterfaceCheckSame(p1.ResourceTypes, p2.ResourceTypes)
 	out.Resources, resourcesOK = mergeArrayInterfaceCheckSame(p1.Resources, p2.Resources)
-	out.extraTemplates = append(p1.extraTemplates, p2.extraTemplates...)
+	// p2 is always a sub-pipeline parsed from a merged YAML file (built via
+	// mapInterfaceInterfaceToPipeline), so it never carries the CLI-supplied
+	// template loading context. Only p1 does — propagate it as-is.
+	out.extraTemplates = p1.extraTemplates
 	out.templateIndex = p1.templateIndex
 
 	if !resourceTypesOK && !resourcesOK {

--- a/pkg/pipeline/merge.go
+++ b/pkg/pipeline/merge.go
@@ -16,6 +16,7 @@ func merge(p1 Pipeline, p2 Pipeline) (Pipeline, error) {
 	out.ResourceTypes, resourceTypesOK = mergeArrayInterfaceCheckSame(p1.ResourceTypes, p2.ResourceTypes)
 	out.Resources, resourcesOK = mergeArrayInterfaceCheckSame(p1.Resources, p2.Resources)
 	out.extraTemplates = append(p1.extraTemplates, p2.extraTemplates...)
+	out.templateIndex = p1.templateIndex
 
 	if !resourceTypesOK && !resourcesOK {
 		return Pipeline{}, fmt.Errorf("resourceTypes and resource merge error;  two or more items that are not identical")

--- a/pkg/pipeline/transform.go
+++ b/pkg/pipeline/transform.go
@@ -240,25 +240,8 @@ func funcMap(t *template.Template) template.FuncMap {
 		"fromYaml":  fromYaml,
 		"toJson":    toJson,
 		"fromJson":  fromJson,
-		"exists": func(name string) bool {
-			return t.Lookup(name) != nil
-		},
-		"include": func(name string, data ...interface{}) (string, error) {
-			var templateData interface{}
-
-			if len(data) == 1 {
-				// Convert a 1-element []T to T
-				templateData = data[0]
-			} else if len(data) > 1 {
-				templateData = data
-			}
-
-			buf := bytes.NewBuffer(nil)
-			if err := t.ExecuteTemplate(buf, name, templateData); err != nil {
-				return "", err
-			}
-			return buf.String(), nil
-		},
+		"exists":    exists(t),
+		"include":   include(t),
 		"skipLines": skipLines,
 	}
 
@@ -267,6 +250,34 @@ func funcMap(t *template.Template) template.FuncMap {
 	}
 
 	return f
+}
+
+// exists and include are factories: they close over the current template set
+// so the returned function can look up associated templates by name at
+// render time.
+func exists(t *template.Template) func(string) bool {
+	return func(name string) bool {
+		return t.Lookup(name) != nil
+	}
+}
+
+func include(t *template.Template) func(string, ...interface{}) (string, error) {
+	return func(name string, data ...interface{}) (string, error) {
+		var templateData interface{}
+
+		if len(data) == 1 {
+			// Convert a 1-element []T to T
+			templateData = data[0]
+		} else if len(data) > 1 {
+			templateData = data
+		}
+
+		buf := bytes.NewBuffer(nil)
+		if err := t.ExecuteTemplate(buf, name, templateData); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	}
 }
 
 func skipLines(numberOfLines int, str string) string {

--- a/pkg/pipeline/transform.go
+++ b/pkg/pipeline/transform.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -164,6 +165,8 @@ func mapInterfaceInterfaceToMapStringInterface(data map[interface{}]interface{})
 func getYamlMap(filename string, index map[string]string) string {
 	if data, err := ioutil.ReadFile(filename); err == nil {
 		return string(data)
+	} else if !os.IsNotExist(err) {
+		log.Fatalf("Template unable to be read: %s: %v", filename, err)
 	}
 
 	if resolved, ok := index[filepath.Base(filename)]; ok {

--- a/pkg/pipeline/transform.go
+++ b/pkg/pipeline/transform.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,14 +162,14 @@ func mapInterfaceInterfaceToMapStringInterface(data map[interface{}]interface{})
 // to looking the basename up in index — the same lookup scheme text/template
 // uses for `{{ template }}` and `{{ include }}`.
 func getYamlMap(filename string, index map[string]string) string {
-	if data, err := ioutil.ReadFile(filename); err == nil {
+	if data, err := os.ReadFile(filename); err == nil {
 		return string(data)
 	} else if !os.IsNotExist(err) {
 		log.Fatalf("Template unable to be read: %s: %v", filename, err)
 	}
 
 	if resolved, ok := index[filepath.Base(filename)]; ok {
-		if data, err := ioutil.ReadFile(resolved); err == nil {
+		if data, err := os.ReadFile(resolved); err == nil {
 			return string(data)
 		}
 	}

--- a/pkg/pipeline/transform.go
+++ b/pkg/pipeline/transform.go
@@ -240,6 +240,9 @@ func funcMap(t *template.Template) template.FuncMap {
 		"fromYaml":  fromYaml,
 		"toJson":    toJson,
 		"fromJson":  fromJson,
+		"exists": func(name string) bool {
+			return t.Lookup(name) != nil
+		},
 		"include": func(name string, data ...interface{}) (string, error) {
 			var templateData interface{}
 

--- a/pkg/pipeline/transform.go
+++ b/pkg/pipeline/transform.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -21,6 +22,7 @@ type Pipeline struct {
 	ResourceTypes  []interface{} `yaml:"resource_types,omitempty"`
 	Jobs           []interface{} `yaml:"jobs,omitempty"`
 	extraTemplates []string
+	templateIndex  map[string]string
 }
 
 type mergeConfig struct {
@@ -43,7 +45,20 @@ func NewPipeline(pipeline string, args map[string]interface{}, templates []strin
 	}
 
 	p.extraTemplates = templates
+	p.templateIndex = buildTemplateIndex(templates)
 	return &p, nil
+}
+
+// buildTemplateIndex keys each template file by its basename, matching the
+// naming scheme text/template's ParseFiles uses for associated templates. This
+// lets `merge:` lookups fall back to the same set that `{{ template }}` and
+// `{{ include }}` resolve against.
+func buildTemplateIndex(templates []string) map[string]string {
+	index := make(map[string]string, len(templates))
+	for _, f := range templates {
+		index[filepath.Base(f)] = f
+	}
+	return index
 }
 
 // Transform takes the current pipeline and begins recursive transformation to produce the finished pipeline.
@@ -55,6 +70,7 @@ func (p *Pipeline) Transform() (*Pipeline, error) {
 		ResourceTypes:  p.ResourceTypes,
 		Jobs:           p.Jobs,
 		extraTemplates: p.extraTemplates,
+		templateIndex:  p.templateIndex,
 	}
 
 	log.Infof("Merging %d merge clauses...", len(p.Merge))
@@ -63,7 +79,7 @@ func (p *Pipeline) Transform() (*Pipeline, error) {
 			c := mapInterfaceInterfaceToMapStringInterface(v.(map[interface{}]interface{}))
 			if mc, ok := mergeConfigFromTemplateWithParams(c); ok {
 				log.Infof("Merging: %v", &mc)
-				cp := mapInterfaceInterfaceToPipeline(stringToMapInterfaceInterface(transformTemplateWithParams(mc.Parameters, getYamlMap(mc.FilePath), pipeline.extraTemplates)))
+				cp := mapInterfaceInterfaceToPipeline(stringToMapInterfaceInterface(transformTemplateWithParams(mc.Parameters, getYamlMap(mc.FilePath, pipeline.templateIndex), pipeline.extraTemplates)))
 				pipelineBeforeMerge := pipeline
 				pipeline, err = merge(pipeline, cp)
 				if err != nil {
@@ -141,12 +157,23 @@ func mapInterfaceInterfaceToMapStringInterface(data map[interface{}]interface{})
 	return m
 }
 
-func getYamlMap(filename string) string {
-	yamlFile, err := ioutil.ReadFile(filename)
-	if err != nil {
-		log.Fatalf("Template unable to be read.\n%v", err)
+// getYamlMap resolves a `merge:` template reference. It first reads the path
+// literally (preserving the existing CWD-relative behaviour), then falls back
+// to looking the basename up in index — the same lookup scheme text/template
+// uses for `{{ template }}` and `{{ include }}`.
+func getYamlMap(filename string, index map[string]string) string {
+	if data, err := ioutil.ReadFile(filename); err == nil {
+		return string(data)
 	}
-	return string(yamlFile)
+
+	if resolved, ok := index[filepath.Base(filename)]; ok {
+		if data, err := ioutil.ReadFile(resolved); err == nil {
+			return string(data)
+		}
+	}
+
+	log.Fatalf("Template unable to be read: %s", filename)
+	return ""
 }
 
 func transformTemplateWithParams(params interface{}, t string, ts []string) string {

--- a/pkg/pipeline/transform_test.go
+++ b/pkg/pipeline/transform_test.go
@@ -562,3 +562,35 @@ jobs:
 		t.Errorf("[%v] is not equal to [%v]\n", result, string(expected))
 	}
 }
+
+func TestTransformExistsFunc(t *testing.T) {
+	p := `
+{{- define "present" -}}ignored{{- end -}}
+jobs:
+- name: test
+  a: {{ if exists "present" }}yes_value{{ else }}no_value{{ end }}
+  b: {{ if exists "missing" }}yes_value{{ else }}no_value{{ end }}
+`
+	expectedPipeline := `
+jobs:
+- name: test
+  a: yes_value
+  b: no_value
+`
+	pipeline := new(Pipeline)
+	yaml.Unmarshal([]byte(expectedPipeline), pipeline)
+	expected, _ := yaml.Marshal(pipeline)
+
+	merger, _ := NewPipeline(p, map[string]interface{}{}, nil)
+
+	var err error
+	pipeline, err = merger.Transform()
+	if err != nil {
+		t.Fatalf("Error transforming %v: %v", p, err)
+	}
+
+	result := pipeline.String()
+	if result != string(expected) {
+		t.Errorf("[%v] is not equal to [%v]\n", result, string(expected))
+	}
+}


### PR DESCRIPTION
When adding a directory with templates, requiring that all merge statements within that directory be based on CWD is fragile. By using the same logic that works for template / include, we can make the whole process independent of the CWD (aside from any templates in the CWD). The exists function is included along the same lines - if we have shared templates, not every piece of functionality is guaranteed to be relevant, so using an exists function allows us to avoid defining empty templates in an env.tpl just to satisfy the include requirement that the template exists in some form.